### PR TITLE
Feat/yank reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Tab completion is available for branch and tag names.
 | `m` | Toggle between uncommitted and branch mode |
 | `R` | Refresh diff |
 | `q` | Close zdiff |
+| `y` | Yank file:line reference (e.g., `path/to/file:10-15`) |
 | `?` | Show help |
 
 Press `?` while in zdiff to see all available keymaps.
@@ -126,7 +127,7 @@ require("zdiff").setup({
   -- Default branch for toggle_mode (m key)
   default_branch = "main",
 
-  -- Keymap bindings
+  -- Keymap bindings (defaults)
   keymaps = {
     goto_file = "<CR>",
     toggle = "<Tab>",
@@ -134,6 +135,7 @@ require("zdiff").setup({
     refresh = "R",
     toggle_mode = "m",
     help = "?",
+    yank_ref = "y",
   },
 
   -- Icons for UI elements
@@ -169,20 +171,15 @@ require("zdiff").setup({
 
 #### Custom keymaps
 
+All keymaps can be customized or disabled (set to `false`).
+
 ```lua
 require("zdiff").setup({
   keymaps = {
     goto_file = "o",
     toggle = "<Space>",
+    yank_ref = "gY",  -- or false to disable
   },
-})
-```
-
-#### Expand all files by default
-
-```lua
-require("zdiff").setup({
-  default_expanded = true,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ Tab completion is available for branch and tag names.
 | `m` | Toggle between uncommitted and branch mode |
 | `R` | Refresh diff |
 | `q` | Close zdiff |
-| `y` | Yank file:line reference (e.g., `path/to/file:10-15`) |
+| `y` | Yank file:line reference |
 | `?` | Show help |
+
+`y` works in both normal mode (current line) and visual mode (selection). Outputs file:line or file:start-end for ranges. Deletion lines are ignored; selections spanning multiple hunks produce multiple ranges (e.g., `path:10-15, 1020-1025`).
 
 Press `?` while in zdiff to see all available keymaps.
 

--- a/lua/zdiff/init.lua
+++ b/lua/zdiff/init.lua
@@ -274,34 +274,40 @@ local function get_diff_stats_async(base_ref, done)
       end
     end
 
-    run_command_async({ "git", "diff", "--name-status", diff_target }, function(_, status_result)
-      for _, line in ipairs(status_result) do
-        local status, path = line:match("^(%a)%s+(.+)$")
-        if path and stats[path] then
-          stats[path].status = status
-        elseif path then
-          stats[path] = { insertions = 0, deletions = 0, status = status }
-        end
-      end
-
-      if base_ref then
-        done(stats)
-        return
-      end
-
-      run_command_async({ "git", "ls-files", "--others", "--exclude-standard" }, function(_, untracked_result)
-        for _, path in ipairs(untracked_result) do
-          if path ~= "" and not stats[path] then
-            stats[path] = {
-              insertions = count_file_lines(path),
-              deletions = 0,
-              status = "?",
-            }
+    run_command_async(
+      { "git", "diff", "--name-status", diff_target },
+      function(_, status_result)
+        for _, line in ipairs(status_result) do
+          local status, path = line:match("^(%a)%s+(.+)$")
+          if path and stats[path] then
+            stats[path].status = status
+          elseif path then
+            stats[path] = { insertions = 0, deletions = 0, status = status }
           end
         end
-        done(stats)
-      end)
-    end)
+
+        if base_ref then
+          done(stats)
+          return
+        end
+
+        run_command_async(
+          { "git", "ls-files", "--others", "--exclude-standard" },
+          function(_, untracked_result)
+            for _, path in ipairs(untracked_result) do
+              if path ~= "" and not stats[path] then
+                stats[path] = {
+                  insertions = count_file_lines(path),
+                  deletions = 0,
+                  status = "?",
+                }
+              end
+            end
+            done(stats)
+          end
+        )
+      end
+    )
   end)
 end
 
@@ -415,7 +421,11 @@ local function get_file_diff(filepath, base_ref, status)
 
   local cmd
   if base_ref then
-    cmd = string.format("git diff %s...HEAD -- %s", vim.fn.shellescape(base_ref), vim.fn.shellescape(filepath))
+    cmd = string.format(
+      "git diff %s...HEAD -- %s",
+      vim.fn.shellescape(base_ref),
+      vim.fn.shellescape(filepath)
+    )
   else
     cmd = string.format("git diff HEAD -- %s", vim.fn.shellescape(filepath))
   end
@@ -697,7 +707,14 @@ local function get_syntax_cache_key(file)
   for _, hunk in ipairs(file.hunks) do
     table.insert(
       pieces,
-      string.format("%d:%d:%d:%d:%d", hunk.old_start, hunk.old_count, hunk.new_start, hunk.new_count, #hunk.lines)
+      string.format(
+        "%d:%d:%d:%d:%d",
+        hunk.old_start,
+        hunk.old_count,
+        hunk.new_start,
+        hunk.new_count,
+        #hunk.lines
+      )
     )
     for _, line in ipairs(hunk.lines) do
       table.insert(pieces, line.type .. ":" .. line.text)
@@ -756,7 +773,8 @@ render = function()
   local syntax_highlights = {} -- collected after we know line positions
   local syntax_requests = {}
   local syntax_cfg = M.config.syntax or {}
-  local syntax_mode = normalize_enum(syntax_cfg.mode, { projection = true, hunk = true }, "projection")
+  local syntax_mode =
+    normalize_enum(syntax_cfg.mode, { projection = true, hunk = true }, "projection")
   local markers = {} -- {line_idx, text, hl_group}
   state.line_map = {}
 
@@ -790,7 +808,8 @@ render = function()
       local status_icon = get_status_icon(file.status)
       local add_stat = string.format("+%d", file.insertions)
       local del_stat = string.format("-%d", file.deletions)
-      local file_line = string.format("%s %s %s  %s %s", icon, status_icon, file.path, add_stat, del_stat)
+      local file_line =
+        string.format("%s %s %s  %s %s", icon, status_icon, file.path, add_stat, del_stat)
       table.insert(lines, file_line)
 
       -- Map this line to the file
@@ -855,7 +874,10 @@ render = function()
             }
 
             -- Add diff background highlight
-            table.insert(highlights, { #lines, get_line_highlight(diff_line.type), 0, -1 })
+            table.insert(
+              highlights,
+              { #lines, get_line_highlight(diff_line.type), 0, -1 }
+            )
 
             -- Render +/- markers as virtual text so they are not part of buffer content
             if diff_line.type == "add" then
@@ -876,7 +898,10 @@ render = function()
               })
 
               table.insert(code_lines, diff_line.text)
-              table.insert(code_line_mapping, { buffer_line = #lines, prefix_len = #prefix })
+              table.insert(
+                code_line_mapping,
+                { buffer_line = #lines, prefix_len = #prefix }
+              )
             end
           end
         end
@@ -889,12 +914,15 @@ render = function()
             local projection = state.syntax_projection_cache[cache_key]
             if projection then
               for _, line_info in ipairs(projection_lines) do
-                local side_map = line_info.source_side == "old" and projection.old or projection.new
-                local side_lnum = line_info.source_side == "old" and line_info.old_lnum or line_info.new_lnum
+                local side_map = line_info.source_side == "old" and projection.old
+                  or projection.new
+                local side_lnum = line_info.source_side == "old" and line_info.old_lnum
+                  or line_info.new_lnum
                 if side_lnum and side_map[side_lnum] then
                   for _, cap in ipairs(side_map[side_lnum]) do
                     local col_start = line_info.prefix_len + cap.col_start
-                    local col_end = cap.col_end == -1 and -1 or (line_info.prefix_len + cap.col_end)
+                    local col_end = cap.col_end == -1 and -1
+                      or (line_info.prefix_len + cap.col_end)
                     table.insert(syntax_highlights, {
                       line_info.buffer_line,
                       cap.hl_group,
@@ -917,7 +945,8 @@ render = function()
               if mapping then
                 -- Offset columns by prefix length
                 local col_start = mapping.prefix_len + hl.col_start
-                local col_end = hl.col_end == -1 and -1 or (mapping.prefix_len + hl.col_end)
+                local col_end = hl.col_end == -1 and -1
+                  or (mapping.prefix_len + hl.col_end)
                 table.insert(syntax_highlights, {
                   mapping.buffer_line,
                   hl.hl_group,
@@ -939,14 +968,28 @@ render = function()
   vim.api.nvim_buf_clear_namespace(state.buf, ns_diff, 0, -1)
   for _, hl in ipairs(highlights) do
     local line_idx, hl_group, col_start, col_end = hl[1], hl[2], hl[3], hl[4]
-    vim.api.nvim_buf_add_highlight(state.buf, ns_diff, hl_group, line_idx - 1, col_start, col_end)
+    vim.api.nvim_buf_add_highlight(
+      state.buf,
+      ns_diff,
+      hl_group,
+      line_idx - 1,
+      col_start,
+      col_end
+    )
   end
 
   -- Apply syntax highlights on top (foreground colors)
   vim.api.nvim_buf_clear_namespace(state.buf, ns_syntax, 0, -1)
   for _, hl in ipairs(syntax_highlights) do
     local line_idx, hl_group, col_start, col_end = hl[1], hl[2], hl[3], hl[4]
-    vim.api.nvim_buf_add_highlight(state.buf, ns_syntax, hl_group, line_idx - 1, col_start, col_end)
+    vim.api.nvim_buf_add_highlight(
+      state.buf,
+      ns_syntax,
+      hl_group,
+      line_idx - 1,
+      col_start,
+      col_end
+    )
   end
 
   -- Apply virtual +/- markers in the left padding columns
@@ -1081,8 +1124,16 @@ local function yank_ref(start_line, end_line)
   end
 
   vim.fn.setreg('"', ref)
-  vim.fn.setreg('+', ref)
+  vim.fn.setreg("+", ref)
   notify("Yanked: " .. ref)
+end
+
+_G.yank_ref_visual = function()
+  local start_pos = vim.fn.getpos("'<")
+  local end_pos = vim.fn.getpos("'>")
+  local start_line = start_pos[2]
+  local end_line = end_pos[2]
+  yank_ref(start_line, end_line)
 end
 
 ---Show help in a floating window
@@ -1307,7 +1358,9 @@ function M.open(base_ref)
 
   -- Validate the ref if provided
   if base_ref and base_ref ~= "" then
-    vim.fn.system("git rev-parse --verify " .. vim.fn.shellescape(base_ref) .. " 2>/dev/null")
+    vim.fn.system(
+      "git rev-parse --verify " .. vim.fn.shellescape(base_ref) .. " 2>/dev/null"
+    )
     if vim.v.shell_error ~= 0 then
       notify("Invalid git ref: " .. base_ref, vim.log.levels.ERROR)
       return
@@ -1360,12 +1413,15 @@ function M.open(base_ref)
     vim.keymap.set("n", M.config.keymaps.yank_ref, function()
       local cursor_line = vim.api.nvim_win_get_cursor(state.win)[1]
       yank_ref(cursor_line, cursor_line)
-    end, opts)
-    vim.keymap.set("v", M.config.keymaps.yank_ref, function()
-      local start_line = vim.api.nvim_buf_get_mark(state.buf, "<")[1]
-      local end_line = vim.api.nvim_buf_get_mark(state.buf, ">")[1]
-      yank_ref(start_line, end_line)
-    end, opts)
+    end, { buffer = state.buf, silent = true })
+    local yank_ref_key = M.config.keymaps.yank_ref
+    vim.api.nvim_buf_set_keymap(
+      state.buf,
+      "v",
+      yank_ref_key,
+      ":lua yank_ref_visual()<CR>",
+      { silent = true }
+    )
   end
 
   -- Auto-refresh when returning to zdiff buffer

--- a/lua/zdiff/init.lua
+++ b/lua/zdiff/init.lua
@@ -1080,8 +1080,19 @@ end
 ---@param end_line number
 local function yank_ref(start_line, end_line)
   local file_idx = nil
-  local lnum_start = nil
-  local lnum_end = nil
+  local ranges = {}
+  local current_range = nil
+
+  local function add_to_range(lnum)
+    if not current_range then
+      current_range = { start = lnum, finish = lnum }
+    elseif lnum == current_range.finish + 1 then
+      current_range.finish = lnum
+    else
+      table.insert(ranges, current_range)
+      current_range = { start = lnum, finish = lnum }
+    end
+  end
 
   for line = start_line, end_line do
     local mapping = state.line_map[line]
@@ -1097,18 +1108,22 @@ local function yank_ref(start_line, end_line)
       return
     end
 
-    local lnum = mapping.lnum
-    if not lnum then
-      lnum = 1
+    if mapping.line_idx and mapping.hunk_idx then
+      local file = state.files[mapping.file_idx]
+      if file and file.hunks[mapping.hunk_idx] then
+        local diff_line = file.hunks[mapping.hunk_idx].lines[mapping.line_idx]
+        if diff_line.type ~= "del" then
+          local lnum = mapping.lnum
+          if lnum then
+            add_to_range(lnum)
+          end
+        end
+      end
     end
+  end
 
-    if not lnum_start then
-      lnum_start = lnum
-      lnum_end = lnum
-    else
-      lnum_start = math.min(lnum_start, lnum)
-      lnum_end = math.max(lnum_end, lnum)
-    end
+  if current_range then
+    table.insert(ranges, current_range)
   end
 
   local file = state.files[file_idx]
@@ -1116,13 +1131,21 @@ local function yank_ref(start_line, end_line)
     return
   end
 
-  local ref
-  if lnum_start == lnum_end then
-    ref = file.path .. ":" .. lnum_start
-  else
-    ref = file.path .. ":" .. lnum_start .. "-" .. lnum_end
+  if #ranges == 0 then
+    notify("Cannot yank: no addition or context lines in selection", vim.log.levels.WARN)
+    return
   end
 
+  local parts = {}
+  for _, r in ipairs(ranges) do
+    if r.start == r.finish then
+      table.insert(parts, tostring(r.start))
+    else
+      table.insert(parts, tostring(r.start) .. "-" .. tostring(r.finish))
+    end
+  end
+
+  local ref = file.path .. ":" .. table.concat(parts, ", ")
   vim.fn.setreg('"', ref)
   vim.fn.setreg("+", ref)
   notify("Yanked: " .. ref)

--- a/lua/zdiff/init.lua
+++ b/lua/zdiff/init.lua
@@ -78,6 +78,7 @@ M.config = {
     refresh = "R",
     toggle_mode = "m",
     help = "?",
+    yank_ref = "y",
   },
   icons = {
     collapsed = "",
@@ -1031,6 +1032,59 @@ goto_source = function()
   vim.cmd("normal! zz") -- Center the line
 end
 
+---Yank a file:line reference for the current line or visual selection
+---@param start_line number
+---@param end_line number
+local function yank_ref(start_line, end_line)
+  local file_idx = nil
+  local lnum_start = nil
+  local lnum_end = nil
+
+  for line = start_line, end_line do
+    local mapping = state.line_map[line]
+    if not mapping or not mapping.file_idx then
+      notify("Cannot yank: line " .. line .. " is not a diff line", vim.log.levels.WARN)
+      return
+    end
+
+    if not file_idx then
+      file_idx = mapping.file_idx
+    elseif file_idx ~= mapping.file_idx then
+      notify("Cannot yank: selection spans multiple files", vim.log.levels.WARN)
+      return
+    end
+
+    local lnum = mapping.lnum
+    if not lnum then
+      lnum = 1
+    end
+
+    if not lnum_start then
+      lnum_start = lnum
+      lnum_end = lnum
+    else
+      lnum_start = math.min(lnum_start, lnum)
+      lnum_end = math.max(lnum_end, lnum)
+    end
+  end
+
+  local file = state.files[file_idx]
+  if not file then
+    return
+  end
+
+  local ref
+  if lnum_start == lnum_end then
+    ref = file.path .. ":" .. lnum_start
+  else
+    ref = file.path .. ":" .. lnum_start .. "-" .. lnum_end
+  end
+
+  vim.fn.setreg('"', ref)
+  vim.fn.setreg('+', ref)
+  notify("Yanked: " .. ref)
+end
+
 ---Show help in a floating window
 show_help = function()
   local keymaps = {
@@ -1041,6 +1095,10 @@ show_help = function()
     { M.config.keymaps.close, "Close zdiff" },
     { M.config.keymaps.help, "Show this help" },
   }
+
+  if M.config.keymaps.yank_ref then
+    table.insert(keymaps, { M.config.keymaps.yank_ref, "Yank file:line reference" })
+  end
 
   -- Find the longest description to calculate width
   local max_desc_len = 0
@@ -1297,6 +1355,18 @@ function M.open(base_ref)
   vim.keymap.set("n", M.config.keymaps.refresh, refresh, opts)
   vim.keymap.set("n", M.config.keymaps.toggle_mode, toggle_mode, opts)
   vim.keymap.set("n", M.config.keymaps.help, show_help, opts)
+
+  if M.config.keymaps.yank_ref then
+    vim.keymap.set("n", M.config.keymaps.yank_ref, function()
+      local cursor_line = vim.api.nvim_win_get_cursor(state.win)[1]
+      yank_ref(cursor_line, cursor_line)
+    end, opts)
+    vim.keymap.set("v", M.config.keymaps.yank_ref, function()
+      local start_line = vim.api.nvim_buf_get_mark(state.buf, "<")[1]
+      local end_line = vim.api.nvim_buf_get_mark(state.buf, ">")[1]
+      yank_ref(start_line, end_line)
+    end, opts)
+  end
 
   -- Auto-refresh when returning to zdiff buffer
   vim.api.nvim_create_autocmd("BufEnter", {

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,4 @@
+indent_type = "Spaces"
+indent_width = 2
+column_width = 90
+line_endings = "Unix"


### PR DESCRIPTION
Creates a default "yank" behavior in the zdiff view. Solves #9 

Yanked behavior
* Normal mode: `y` -> relative/path/to/file:10
* Visual mode: `y` -> relative/path/to/file:10-15

When selecting across hunks, you get multi-range -> relative/path/to/file:10-15, 1020-1025

Selection on deleted lines is ignored. If you want the option to yank deleted lines(content), you can always override the default keybinding, so `y` works as expected.